### PR TITLE
fix: separating operator and version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">=0.14.0"
   required_providers {
     google = {
-      version = ">=v4.0.0"
+      version = ">= v4.0.0"
     }
   }
 }


### PR DESCRIPTION
In order to avoid the "Error: Invalid version constraint", it is necessary to have a space between the operator and the version.