### PR TITLE
fix version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">=0.14.0"
   required_providers {
     google = {
-      version = ">= v4.0.0"
+      version = ">=4.0.0"
     }
   }
 }


### PR DESCRIPTION
I've made some changes to fix the issue with terraform failing to initialize due to an invalid version constraint. The issue was caused by the "v" prefix used in the version constraint syntax for the Google provider module.

I've removed the "v" prefix from the version constraint, and the terraform initialization is now working correctly.

Please take a look at the changes and let me know if you have any feedback or questions.